### PR TITLE
Implement JWT auth and memory listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ Este projeto está licenciado sob a Licença MIT - veja o arquivo [LICENSE](LICE
 - 📖 Docs: [docs.beststag.com](https://docs.beststag.com)
 - 🐛 Issues: [GitHub Issues](https://github.com/seu-usuario/beststag-v9.1/issues)
 
----
-
-**BestStag v9.1** - Transformando conversas em inteligência 🧠✨
+### Principais Rotas da API
+- `POST /api/memory/cleanup`
+- `GET /api/memory/list`
+- `GET /api/user/export`
+- `DELETE /api/user/delete`
+- `GET /api/email/summary`
+Todas exigem header Authorization: Bearer <token>.

--- a/src/backend/services/auth_service.py
+++ b/src/backend/services/auth_service.py
@@ -1,0 +1,34 @@
+import os
+from datetime import datetime, timedelta
+
+import jwt
+from fastapi import Depends, HTTPException, Request
+
+
+def create_access_token(user_id: str) -> str:
+    """Generate JWT token with 24h expiration."""
+    payload = {
+        "sub": user_id,
+        "exp": datetime.utcnow() + timedelta(hours=24),
+    }
+    secret = os.getenv("JWT_SECRET")
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def verify_access_token(token: str) -> str:
+    """Validate token and return user_id."""
+    secret = os.getenv("JWT_SECRET")
+    try:
+        payload = jwt.decode(token, secret, algorithms=["HS256"])
+    except jwt.PyJWTError as exc:
+        raise HTTPException(status_code=401, detail="Token inválido ou expirado") from exc
+    return payload.get("sub")
+
+
+async def get_current_user(request: Request) -> str:
+    """Retrieve logged in user from Authorization header."""
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Token inválido ou expirado")
+    token = auth_header.split(" ", 1)[1]
+    return verify_access_token(token)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,16 @@
+import pytest
+from fastapi import HTTPException
+
+from src.backend.services.auth_service import create_access_token, verify_access_token
+
+
+def test_create_and_verify_token():
+    token = create_access_token("user123")
+    user_id = verify_access_token(token)
+    assert user_id == "user123"
+
+
+def test_invalid_token_raises():
+    token = create_access_token("user123")
+    with pytest.raises(HTTPException):
+        verify_access_token(token + "x")


### PR DESCRIPTION
## Summary
- add `auth_service` with JWT utilities
- secure memory-related routes using logged user
- expose paginated memory list endpoint
- document main routes in README
- add unit tests for auth token handling

## Testing
- `make lint` *(fails: E402, F401 etc.)*
- `make test` *(fails: ImportError in tests/conftest)*

------
https://chatgpt.com/codex/tasks/task_e_68433c6e7e24832888437ad4b317a071